### PR TITLE
fix branches specified in publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -7,7 +7,7 @@ site:
 content:
   sources:
   - url: https://github.com/neo4j-drivers/docs-bolt.git
-    branches: ['master', 'dev']
+    branches: ['main']
     exclude:
     - '!**/_includes/*'
     - '!**/readme.adoc'


### PR DESCRIPTION
As long as there is a single version of the Bolt docs content, we don't need to use this playbook, but if it is to be here, it should be accurate.