### PR TITLE
Fix 2 minor typos in PackStream specification

### DIFF
--- a/modules/ROOT/pages/packstream/index.adoc
+++ b/modules/ROOT/pages/packstream/index.adoc
@@ -139,7 +139,7 @@ This means that the most significant part of the value is written to the network
 [[data-type-null]]
 === `Null`
 
-*Marker:* `C2`
+*Marker:* `C0`
 
 `Null` is always encoded using the single marker byte `C0`.
 
@@ -150,7 +150,7 @@ This means that the most significant part of the value is written to the network
 
 *Marker, true:* `C3`
 
-Boolean values are encoded within a single marker byte, using `C3` to denote *true* and `C2`to denote *false*.
+Boolean values are encoded within a single marker byte, using `C3` to denote *true* and `C2` to denote *false*.
 
 [[data-type-integer]]
 === `Integer`


### PR DESCRIPTION
See title.

Before:
![](https://user-images.githubusercontent.com/14951909/165132959-817643c2-2c24-4a74-af64-d4c7b2248380.png)

After:
![](https://user-images.githubusercontent.com/14951909/165133131-2f96384f-76f4-4644-a5a5-9393ab75873c.png)